### PR TITLE
Add `--only task_id={number}` to useful `mix test` options

### DIFF
--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -129,6 +129,7 @@ Documentation:
   in the same order they were defined in
 * `--stale` - runs only tests which reference modules that changed since the last
   time tests were ran with `--stale`
+* `--only task-id:1` - or with another number, on learning exercises runs only the tests associated with the instructions' number
 
 Documentation:
 


### PR DESCRIPTION
Hello, this is my first time trying to contribute here. I have read HELLO.md and CONTRIBUTING.md, and I hope this PR meets the criteria.

I came across this option while inspecting the help guide of `mix test` and I have found it quite fitting for the way I approach learning exercises in the platform. Which is:

1. Read the instructions
2. Pull the code with the CLI command
3. Read the next instruction (task) and try to implement it locally
4. Run `mix test --only task_id:{instruction_number}`
5. Fix it if needed
6. Repeat from step 3 for the next instruction
7. After the last instruction is completed, run `mix test` to check everything

Before finding out about this option I was running all tests together but that created a lot of noise, now I can tackle each instruction one after the other. That's why I think it could be useful to share it with other users who prefer working locally on the exercises.